### PR TITLE
Use unique loop variable names

### DIFF
--- a/tasks/platform/Debian.yml
+++ b/tasks/platform/Debian.yml
@@ -15,19 +15,19 @@
 - name: ensure repo presence
   become: true
   apt_repository:
-    repo: "deb http://apt.llvm.org/{{ ansible_distribution_release | lower }}/ llvm-toolchain-{{ ansible_distribution_release | lower }}-{{ v }} main"    # noqa 204
+    repo: "deb http://apt.llvm.org/{{ ansible_distribution_release | lower }}/ llvm-toolchain-{{ ansible_distribution_release | lower }}-{{ repo_item }} main"    # noqa 204
     state: present
-    filename: clang{{ v }}-stable
+    filename: clang{{ repo_item }}-stable
   loop: "{{ clang_versions }}"
   loop_control:
-    loop_var: v
+    loop_var: repo_item
 
 - name: ensure src repo presence
   become: true
   apt_repository:
-    repo: "deb-src http://apt.llvm.org/{{ ansible_distribution_release | lower }}/ llvm-toolchain-{{ ansible_distribution_release | lower }}-{{ v }} main"    # noqa 204
+    repo: "deb-src http://apt.llvm.org/{{ ansible_distribution_release | lower }}/ llvm-toolchain-{{ ansible_distribution_release | lower }}-{{ src_repo_item }} main"    # noqa 204
     state: present
-    filename: clang{{ v }}-stable
+    filename: clang{{ src_repo_item }}-stable
   loop: "{{ clang_versions }}"
   loop_control:
-    loop_var: v
+    loop_var: src_repo_item


### PR DESCRIPTION
This fixes the following warning emitted by Ansible (2.10.x in my case, but likely some other versions as well):

```
TASK [teebor_choka.clang : ensure repo presence] *******************************
Wednesday 12 May 2021  07:41:45 +0000 (0:00:01.417)       0:11:19.404 ********* 
[WARNING]: The loop variable 'item' is already in use. You should set the
`loop_var` value in the `loop_control` option for the task to something else to
avoid variable collisions and unexpected behavior.
```

Thanks for the nice role!