### PR TITLE
Properly handle older version of clang format.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        scenario:
+          - default
+          - legacy
         distro:
           - ubuntu2004
           - ubuntu1804
@@ -29,6 +32,7 @@ jobs:
       - name: run molecule
         uses: robertdebock/molecule-action@2.6.1
         env:
+          scenario: ${{ matrix.scenario }}
           MOLECULE_DISTRO: ${{ matrix.distro }}
 
   deploy:

--- a/molecule/legacy/molecule.yml
+++ b/molecule/legacy/molecule.yml
@@ -1,0 +1,26 @@
+---
+
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint -c .yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
+verifier:
+  name: testinfra

--- a/molecule/legacy/playbook.yml
+++ b/molecule/legacy/playbook.yml
@@ -11,5 +11,5 @@
     - role: ansible-role-clang
       vars:
         clang_versions:
-          - 11
+          - 5
         clang_install_tools: true


### PR DESCRIPTION
Extend testing scenario with older clang version and support proper installation of clang tools when selected.

This relates to #2 