### PR TITLE
Add clangd to installed clang utilities

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,4 +41,5 @@
     - clang
     - clang-format
     - clang-tidy
+    - clangd
     - lld

--- a/vars/packages.yml
+++ b/vars/packages.yml
@@ -17,6 +17,7 @@ advanced_packages:
   - clang-format-{{ clang_version }}
   - clang-tidy-{{ clang_version }}
   - clang-{{ clang_version }}-doc
+  - clangd-{{ clang_version }}
   - libclang-common-{{ clang_version }}-dev
   - libclang-{{ clang_version }}-dev
   - libclang1-{{ clang_version }}


### PR DESCRIPTION
Added the `clangd` language server to the list of advanced packages that may be installed. Also added `clangd` to the list of alternatives for clang.

Closes #9 